### PR TITLE
Copilot/add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,3 @@
 .github/ export-ignore
 .release-please-manifest.json export-ignore
 release-please-config.json export-ignore
-CHANGELOG.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Export ignores for Composer releases
+.gitattributes export-ignore
+.gitignore export-ignore
+.github/ export-ignore
+.release-please-manifest.json export-ignore
+release-please-config.json export-ignore
+CHANGELOG.md export-ignore


### PR DESCRIPTION
Composer installs include CI config, release tooling, and other dev-only files that have no runtime value for package consumers.

## Changes

- **`.gitattributes`** — new file with `export-ignore` directives for:
  - `.gitattributes`, `.gitignore` — repo metadata
  - `.github/` — CI/CD workflows
  - `.release-please-manifest.json`, `release-please-config.json` — release tooling

`CHANGELOG.md`, `README.md`, and `LICENSE.md` are intentionally kept in the export.
